### PR TITLE
Teeny dx upload change

### DIFF
--- a/.github/workflows/test_changes.yml
+++ b/.github/workflows/test_changes.yml
@@ -142,7 +142,7 @@ jobs:
           FOLDER_NAME: ${{ steps.get-create-project.outputs.FOLDER_NAME }}
         id: upload-config
         run: |
-          FILE_ID=$(dx upload ${CHANGED_FILE} --destination ${TEST_PROJ_ID}:/${FOLDER_NAME}/ --brief)
+          FILE_ID=$(dx upload ${CHANGED_FILE} --destination ${TEST_PROJ_ID}:/${FOLDER_NAME}/ --wait --brief)
           echo "Config file uploaded to DNAnexus project ${TEST_PROJ_ID}. File ID: $FILE_ID"
           echo "FILE_ID=$FILE_ID" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
- Add `--wait` to dx upload command to wait until config file finishes closing so we don't try to diff using `cat` of a non-closed config when the workflow is too speedy for its own good (crycat emoji)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/GitHub_Actions/16)
<!-- Reviewable:end -->
